### PR TITLE
Wm visitor restrictions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,4 +5,8 @@ class ApplicationController < ActionController::Base
   def current_user
     @current_user ||= User.find(session[:user_id]) if session[:user_id]
   end
+
+  def require_user
+    render file: 'public/404', status: 404 unless current_user
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
+  before_action :require_user
 
   def show
   end

--- a/spec/features/welcome/nav_bar_restrictions_spec.rb
+++ b/spec/features/welcome/nav_bar_restrictions_spec.rb
@@ -19,4 +19,10 @@ RSpec.describe 'Navbar Links', type: :feature do
     expect(page).to have_content('Profile')
     expect(page).to have_content('Log Out')
   end
+
+  it 'visitor cannot navigate to profile' do
+    visit '/profile'
+    expect(page.status_code).to eq(404)
+  end
+
 end


### PR DESCRIPTION
Created a before action in the user controller to verify user before displaying profile page. If there is not a user in session, 404 page will be rendered. Coverage 100%. 